### PR TITLE
Moved tutorials from pyramid_tutorials to the cookbook

### DIFF
--- a/catalog.rst
+++ b/catalog.rst
@@ -1,0 +1,127 @@
+.. _catalog_tutorial:
+
+Using :mod:`repoze.catalog` Within :app:`Pyramid`
+=================================================
+
+:mod:`repoze.catalog` is a ZODB-based system that can be used to index
+Python objects.  It also offers a query interface for retrieving
+previously indexed data.  Those whom are used to Zope's "ZCatalog"
+implementation will feel at home using :mod:`repoze.catalog`.
+
+This tutorial assumes that you want a Zope-like setup.  For example,
+it assumes you want to use a persistent ZODB object as your
+:term:`root` object, and that the :mod:`repoze.catalog` catalog will
+be an attribute of this root object.  It is further assumed that you
+want the application to be based on :term:`traversal`.
+
+#. Follow the :ref:`zodb_with_zeo` tutorial to get a system set up
+   with ZODB and ZEO.  When you are finished, come back here.
+
+#. Install the :mod:`repoze.catalog` software within your application's
+   environment:
+
+   .. code-block:: text
+   
+      $ easy_install repoze.catalog
+
+#. Change your ZODB application's ``models.py`` file to look like the
+   below:
+
+   .. code-block:: python
+      :linenos:
+
+       from repoze.folder import Folder
+       from repoze.catalog.catalog import Catalog
+       from repoze.catalog.document import DocumentMap
+       from repoze.catalog.indexes.field import CatalogFieldIndex
+
+       def get_title(object, default):
+           title = getattr(object, 'title', '')
+           if isinstance(title, basestring):
+               # lowercase for alphabetic sorting
+               title = title.lower()
+           return title
+
+       class Document(Folder):
+           def __init__(self, title):
+               self.title = title
+               Folder.__init__(self)
+
+       class Site(Folder):
+           def __init__(self):
+               self.catalog = Catalog()
+               self.catalog.document_map = DocumentMap()
+               self.update_indexes()
+               Folder.__init__(self)
+
+           def update_indexes(self):
+               indexes = {
+                   'title': CatalogFieldIndex(get_title),
+               }
+
+               catalog = self.catalog
+
+               # add indexes
+               for name, index in indexes.iteritems():
+                   if name not in catalog:
+                       catalog[name] = index
+
+               # remove indexes
+               for name in catalog.keys():
+                   if name not in indexes:
+                       del catalog[name]
+
+       def appmaker(root):
+           if not 'site' in root:
+               root['site'] = Site()
+               transaction.commit()
+           return root['site']
+
+#.  We'll demonstrate how you might interact with a catalog from code
+    by manipulating the database directly using the ``pshell``
+    command in a terminal window:
+
+    .. code-block:: text
+
+       [chrism@snowpro sess]$ ../bin/paster pshell \
+              development.ini myapp
+       Python 2.5.4 (r254:67916, Sep  4 2009, 02:12:16) 
+       [GCC 4.2.1 (Apple Inc. build 5646)] on darwin
+       Type "help" for more information. "root" is the Pyramid app root.
+       >>> from pyramid.traversal import resource_path
+       >>> from myapp.models import Document
+       >>> root['name'] = Document('title')
+       >>> doc = root['name']
+       >>> docid = root.catalog.document_map.add(resource_path(doc))
+       >>> root.catalog.index_doc(docid, doc)
+       >>> import transaction
+       >>> transaction.commit()
+       >>> root.catalog.search(title='title')
+       (1, IFSet([-787959756]))
+
+As you need them, add other indexes required by your application to
+the catalog by modifying the ``update_indexes`` method of the ``Site``
+object.  Whenever an index is added or removed, invoke the
+``update_indexes`` method of the site (the root object) from a script
+or from within a ``pshell`` session to update the set of indexes
+used by your application.
+
+In :term:`view` code, you should be able to get a hold of he root
+object via the :func:`pyramid.traversal.find_root` API.  The
+``catalog`` attribute of that root object will represent the catalog
+previously added.
+
+Read the :mod:`repoze.catalog` `documentation
+<http://docs.repoze.org/catalog>`_ for further information about other
+types of indexes to add, using the document map, and how to issue
+queries using the catalog query API.
+
+.. note::
+
+   The :mod:`repoze.folder` implementation sends events that can be
+   intercepted by a :term:`subscriber` when objects are added and
+   removed from a folder.  It is often useful to hook these events for
+   the purpose of mutating the catalog when a new documentlike object
+   is added or removed.  See the `repoze.folder documentation
+   <http://docs.repoze.org/folder>`_ for more information about the
+   events it sends.

--- a/cmf/actions.rst
+++ b/cmf/actions.rst
@@ -1,0 +1,28 @@
+.. _actions_chapter:
+
+=======
+Actions
+=======
+
+In CMF, the "actions tool" along with "action providers" create an extensible
+mechanism to show links in the CMF management UI that invoke a particular
+behavior or which show a particular template.
+
+:app:`Pyramid` itself has no such concept, and no package provides a direct
+replacement.  Actions are such a generic concept that it's simple to
+reimplement action-like navigation in a different way within any given
+application.  For example, a module-scope global dictionary which has keys
+that are action names, and values which are tuples of (permission, link).
+Take that concept and expand on it, and you'll have some passable actions
+tool replacement within a single application.
+
+The `pyramid_viewgroup <https://github.com/Pylons/pyramid_viewgroup/>`_
+package provides some functionality for creating "view groups".  Each view in
+a viewgroup can provide some snippet of HTML (e.g. a single "tab"), and
+individual views (tabs) within the group which cannot be displayed to the
+user due to the user's lack of permissions will be omitted from the rendered
+output.
+
+The :term:`repoze.lemonade` package provides "list item" support that
+may be used to construct action lists.
+

--- a/cmf/catalog.rst
+++ b/cmf/catalog.rst
@@ -1,0 +1,73 @@
+.. _catalog_chapter:
+
+=======
+Catalog
+=======
+
+The main feature of the CMF catalog is that it filters search results
+from the Zope 2 "catalog" based on the requesting user's ability to
+view a particular cataloged object.
+
+:app:`Pyramid` itself has no cataloging facility, but an addon
+package named :term:`repoze.catalog` offers similar functionality.
+
+Creating an Allowed Index
+-------------------------
+
+In CMF, a catalog index named ``getAllowedRolesAndUsers`` along with
+application indexing code allows for filtered search results.  It's
+reasonably easy to reproduce this pattern using some custom code.
+
+Creating The ``allowed`` Index
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Here's some code which creates an ``allowed`` index for use in a
+``repoze.catalog`` catalog::
+
+    from pyramid.security import principals_allowed_by_permission
+    from repoze.catalog.indexes.keyword import CatalogKeywordIndex
+    from repoze.catalog.catalog import Catalog
+
+    class Allowed:
+        def __init__(self, permission):
+            self.permission = permission
+
+        def __call__(self, context, default):
+            principals = principals_allowed_by_permission(context, 
+                                                          self.permission)
+            return principals
+
+    def make_allowed_index(permission='View'):
+        index = CatalogKeywordIndex(Allowed(permission))
+        return index
+
+    index = make_allowed_index()
+    catalog = Catalog()
+    catalog['allowed'] = index
+
+When you index an item, the allowed index will be populated with all
+the principal ids which have the 'View' permission.
+
+Using the ``allowed`` Index
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Here's how you might use the ``allowed`` index within a query::
+
+  from pyramid.security import effective_principals
+  principals = effective_principals(request)
+  catalog.searchResults(allowed={'operator':'or', 'query':principals})
+
+The above query will return all document ids that the current user has
+the 'View' permission against.  Add other indexes to the query to get
+a useful result.
+
+See the `repoze.catalog package
+<http://svn.repoze.org/repoze.catalog/trunk>`_ for more information.
+
+
+
+
+
+
+
+

--- a/cmf/content.rst
+++ b/cmf/content.rst
@@ -1,0 +1,67 @@
+.. _content_types_chapter:
+
+=============
+Content Types
+=============
+
+In CMF, a content type is defined as a bag of settings (the type
+information, controlled within the "types tool"), as well as factory
+code which generates an instance of that content.  It is possible to
+construct and enumerate content types using APIs defined on the types
+tool.
+
+:app:`Pyramid` itself has no such concept, but an addon package named
+:term:`repoze.lemonade` has a barebones replacement.
+
+Factory Type Information
+------------------------
+
+A factory type information object in CMF allows you to associate a
+title, a description, an internationalization domain, an icon, an
+initial view name, a factory, and a number of security settings with a
+type name.  Each type information object knows how to manufacture
+content objects that match its type.
+
+:app:`Pyramid` certainly enforces none of these concepts in any
+particular way, but :term:`repoze.lemonade` does.
+
+``repoze.lemonade`` Content
++++++++++++++++++++++++++++
+
+:term:`repoze.lemonade` provides a reasonably handy directive and set
+of helper functions which allow you to:
+
+#. Associate a interface with a factory function, making it into a
+   "content type".
+
+#. Enumerate all interfaces associated with factory functions.
+
+.. note:: Using this pattern is often plain silly, as it's usually
+          just as easy to actually import a class implementation and
+          create an instance directly using its constructor.  But it
+          can be useful in cases where you want to address some set of
+          constructors uniformly without doing direct imports in the
+          code which performs the construction, or if you need to make
+          content construction uniform across a diverse set of model
+          types, or if you need to enumerate some set of information
+          about "content" types.  It's left as an exercise to the
+          reader to determine under which circumstances using this
+          pattern is an appropriate thing to do.  Hint: not very
+          often, unless you're doing the indirection solely to aid
+          content-agnostic unit tests or if you need to get an
+          enumerated subset of content type information to aid in UI
+          generation.  That said, this *is* a tutorial about how to
+          get CMF-like features in :app:`Pyramid`, so we'll assume
+          the pattern is useful to readers.
+
+See the `repoze.lemonade package
+<http://svn.repoze.org/repoze.lemonade/trunk>`_ for more information,
+particularly its documentation for "content".
+
+
+
+
+
+
+
+

--- a/cmf/index.rst
+++ b/cmf/index.rst
@@ -1,0 +1,38 @@
+Converting an Existing Zope/CMF Application to :app:`Pyramid`
+================================================================
+
+The Zope `Content Management Framework
+<http://www.zope.org/Products/CMF/>`_ (aka CMF) is a layer on top of
+:term:`Zope` 2 that provides facilities for creating content-driven
+websites.  It's reasonably easy to convert a modern Zope/CMF
+application to :app:`Pyramid`.
+
+The main difference between CMF and :app:`Pyramid` is that :app:`Pyramid`
+does not advertise itself as a system into which you can plug arbitrary
+"packages" that extend a system-supplied management user interface.  You
+*could* build a CMF-like layer on top of :app:`Pyramid` but none currently
+exists.  For those sorts of high-extensibility, highly-regularized-UI
+systems, CMF is still the better choice.
+
+:app:`Pyramid` (and other more lightweight systems) is often a
+better choice when you're building the a user interface from scratch,
+which often happens when the paradigms of some CMF-provided user
+interface don't match the requirements of an application very closely.
+Even so, a good number of developers tend to use CMF even when they do
+start an application for which they need to build a UI from scratch,
+because CMF happens to provide other helpful services, such as types,
+skins, and workflow; this tutorial is for those sorts of developers
+and projects.
+
+.. toctree::
+   :maxdepth: 2
+
+   content.rst
+   catalog.rst
+   skins.rst
+   actions.rst
+   workflow.rst
+   missing.rst
+
+
+

--- a/cmf/missing.rst
+++ b/cmf/missing.rst
@@ -1,0 +1,22 @@
+Missing Comparisons
+===================
+
+We currently don't have any comparative Pyramid-vs-CMF information
+about the following concepts within this tutorial:
+
+- Templates
+
+- Forms
+
+- Membership
+
+- Discussions
+
+- Syndication
+
+- Dublincore
+
+Please ask on the `Pylons-devel maillist
+<http://groups.google.com/group/pylons-devel>`_ or on the `#pylons IRC
+channel <http://irc.freenode.net#pylons>`_ about these topics.
+

--- a/cmf/skins.rst
+++ b/cmf/skins.rst
@@ -1,0 +1,23 @@
+.. _skins_chapter:
+
+=====
+Skins
+=====
+
+In CMF, a "skin layer" is defined as a collection of templates and
+code (Python scripts, DTML methods, etc) that can be activated and
+deactivated within a particular setup.  A collection of active "skin
+layers" grouped in a particular order forms a "skin".  "Add-on" CMF
+products often provide skin layers that are activated within a
+particular skin to provide the site with additional features.
+
+To override static resources using a "search path" much like a set of
+skin layers, :app:`Pyramid` provides the concept of
+:term:`resource` overrides.  See :ref:`overriding_resources_section`
+for more information about resource overrides.
+
+While there is no analogue to a skin layer search path for locating
+Python code (as opposed to resources), :term:`view` code combined with
+differing :term:`predicate` arguments can provide a good deal of
+the same sort of behavior.
+

--- a/cmf/workflow.rst
+++ b/cmf/workflow.rst
@@ -1,0 +1,14 @@
+.. _workflow_chapter:
+
+========
+Workflow
+========
+
+In CMF, the "workflow tool" allows developers to design state machines
+which imply transition between content states.
+
+:app:`Pyramid` itself has no such concept, but the
+:term:`repoze.workflow` package provides a simple state machine
+implementation that can act as a barebones workflow tool.  See its
+documentation for more information.
+

--- a/conf.py
+++ b/conf.py
@@ -13,6 +13,9 @@
 
 import sys, os
 
+from docutils import nodes
+from docutils import utils
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -224,5 +227,16 @@ man_pages = [
      [u'Pylons Project Contributors'], 1)
 ]
 
+def app_role(role, rawtext, text, lineno, inliner, options={}, content=[]):
+    """custom role for :app: marker, does nothing in particular except allow
+    :app:`Pyramid` to work (for later search and replace)."""
+    if 'class' in options:
+        assert 'classes' not in options
+        options['classes'] = options['class']
+        del options['class']
+    return [nodes.inline(rawtext, utils.unescape(text), **options)], []
 
+
+def setup(app):
+    app.add_role('app', app_role)
 

--- a/index.rst
+++ b/index.rst
@@ -9,11 +9,15 @@ The Pyramid Cookbook presents topical, practical usages of :mod:`Pyramid`.
    static
    exceptions
    authentication
+   wiki2_auth
    templates
+   catalog
    sqla
    mongo
    i18n
    interfaces
+   zeo
+   cmf/index.rst
    glossary
 
 TODO

--- a/wiki2_auth.rst
+++ b/wiki2_auth.rst
@@ -1,0 +1,359 @@
+Wiki Flow of Authentication
+===========================
+
+This tutorial describes the "flow of authentication" of the result of the
+completing the :ref:`wiki2_adding_authorization` tutorial chapter from the
+main Pyramid documentation.
+
+This text was contributed by John Shipman.
+
+.. _wiki2_flow_of_authentication:
+
+Overall flow of an authentication
+---------------------------------
+
+Now that you have seen all the pieces of the authentication
+mechanism, here are some examples that show how they all work
+together.
+
+#. Failed login: The user requests ``/FrontPage/edit_page``.  The
+   site presents the login form.  The user enters ``editor`` as
+   the login, but enters an invalid password ``bad``.
+   The site redisplays the login form with the message "Failed
+   login".  See :ref:`failed_login`.
+
+#. The user again requests ``/FrontPage/edit_page``.  The site
+   presents the login form, and this time the user enters
+   login ``editor`` and password ``editor``.  The site presents
+   the edit form with the content of ``/FrontPage``.  The user
+   makes some changes and saves them.  See :ref:`good_login`.
+
+#. The user again revisits ``/FrontPage/edit_page``.  The site
+   goes immediately to the edit form without requesting
+   credentials. See :ref:`revisit`.
+
+#. The user clicks the ``Logout`` link.  See :ref:`logging_out`.
+
+.. _failed_login:
+
+Failed login
+~~~~~~~~~~~~
+
+The process starts when the user enters URL
+``http://localhost:6543/FrontPage/edit_page``.  Let's assume that
+this is the first request ever made to the application and the
+page database is empty except for the ``Page`` instance created
+for the front page by the ``initialize_sql`` function in
+:file:`models.py`.
+
+This process involves two complete request/response cycles.
+
+1. From the front page, the user clicks :guilabel:`Edit page`.
+   The request is to ``/FrontPage/edit_page``.  The view callable
+   is ``login.login``. The response is the ``login.pt`` template
+   with blank fields.
+
+2. The user enters invalid credentials and clicks :guilabel:`Log
+   in`.  A ``POST`` request is sent to ``/FrontPage/edit_page``.
+   The view callable is again ``login.login``.  The response is
+   the ``login.pt`` template showing the message "Failed login",
+   with the entry fields displaying their former values.
+
+Cycle 1:
+
+#. During URL dispatch, the route ``'/{pagename}/edit_page'`` is
+   considered for matching.  The associated view has a
+   ``view_permission='edit'`` permission attached, so the
+   dispatch logic has to verify that the user has that permission
+   or the route is not considered to match.
+   
+   The context for all route matching comes from the configured
+   root factory, :meth:`RootFactory` in :file:`models.py`.
+   This class has an ``__acl__`` attribute that defines the
+   access control list for all routes::
+
+        __acl__ = [ (Allow, Everyone, 'view'),
+                    (Allow, 'group:editors', 'edit') ]
+
+   In practice, this means that for any route that requires the
+   ``edit`` permission, the user must be authenticated and
+   have the ``group:editors`` principal or the route is not
+   considered to match.
+
+#. To find the list of the user's principals, the authorization
+   first policy checks to see if the user has a
+   ``paste.auth.auth_tkt`` cookie.  Since the user has never been
+   to the site, there is no such cookie, and the user is
+   considered to be unauthenticated.
+
+#. Since the user is unauthenticated, the ``groupfinder``
+   function in :file:`security.py` is called with ``None`` as its
+   ``userid`` argument.  The function returns an empty list of
+   principals.
+
+#. Because that list does not contain the ``group:editors``
+   principal, the ``'/{pagename}/edit_page'`` route's ``edit``
+   permission fails, and the route does not match.
+
+#. Because no routes match, the `forbidden view` callable is
+   invoked: the ``login`` function in module ``login.py``.
+
+#. Inside the ``login`` function, the value of ``login_url`` is
+   ``http://localhost:6543/login``, and the value of
+   ``referrer`` is ``http://localhost:6543/FrontPage/edit_page``.
+   
+   Because ``request.params`` has no key for ``'came_from'``, the
+   variable ``came_from`` is also set to
+   ``http://localhost:6543/FrontPage/edit_page``.  Variables
+   ``message``, ``login``, and ``password`` are set to the empty
+   string.
+
+   Because ``request.params`` has no key for
+   ``'form.submitted'``, the ``login`` function returns this
+   dictionary::
+
+    {'message': '', 'url':'http://localhost:6543/login',
+     'came_from':'http://localhost:6543/FrontPage/edit_page',
+     'login':'', 'password':''}
+
+#. This dictionary is used to render the ``login.pt`` template.
+   In the form, the ``action`` attribute is
+   ``http://localhost:6543/login``, and the value of
+   ``came_from`` is included in that form as a hidden field
+   by this line in the template::
+
+       <input type="hidden" name="came_from" value="${came_from}"/>
+
+Cycle 2:
+
+#. The user enters incorrect credentials and clicks the
+   :guilabel:`Log in` button, which does a ``POST`` request to
+   URL ``http://localhost:6543/login``.  The name of the
+   :guilabel:`Log in` button in this form is ``form.submitted``.
+
+#. The route with pattern ``'/login'`` matches this URL, so
+   control is passed again to the ``login`` view callable.
+   
+#. The ``login_url`` and ``referrer`` have the same value
+   this time (``http://localhost:6543/login``), so variable
+   ``referrer`` is set to ``'/'``.
+
+   Since ``request.params`` does have a key ``'form.submitted'``,
+   the values of ``login`` and ``password`` are retrieved from
+   ``request.params``.
+
+   Because the login and password do not match any of the entries
+   in the ``USERS`` dictionary in ``security.py``, variable
+   ``message`` is set to ``'Failed login'``.
+
+   The view callable returns this dictionary::
+
+    {'message':'Failed login',
+     'url':'http://localhost:6543/login', 'came_from':'/',
+     'login':'editor', 'password':'bad'}
+
+#. The ``login.pt`` template is rendered using those values.
+
+.. _good_login:
+
+Successful login
+~~~~~~~~~~~~~~~~
+
+In this scenario, the user again requests URL
+``/FrontPage/edit_page``.
+
+This process involves four complete request/response cycles.
+
+1. The user clicks :guilabel:`Edit page`.  The view callable is
+   ``login.login``.  The response is template ``login.pt``,
+   with all the fields blank.
+
+2. The user enters valid credentials and clicks :guilabel:`Log in`.
+   The view callable is ``login.login``.  The response is a
+   redirect to ``/FrontPage/edit_page``.
+
+3. The view callable is ``views.edit_page``.  The response
+   renders template ``edit.pt``, displaying the current page
+   content.
+
+4. The user edits the content and clicks :guilabel:`Save`.
+   The view callable is ``views.edit_page``.  The response
+   is a redirect to ``/FrontPage``.
+
+Execution proceeds as in :ref:`failed_login`, up to the point
+where the password ``editor`` is successfully matched against the
+value from the ``USERS`` dictionary.
+
+Cycle 2:
+
+#. Within the ``login.login`` view callable, the value of
+   ``login_url`` is ``http://localhost:6543/login``, and the
+   value of ``referrer`` is ``'/'``, and ``came_from`` is
+   ``http://localhost:6543/FrontPage/edit_page`` when this block
+   is executed:
+
+   .. code-block:: python
+
+        if USERS.get(login) == password:
+            headers = remember(request, login)
+            return HTTPFound(location=came_from, headers=headers)
+
+#. Because the password matches this time,
+   :mod:`pyramid.security.remember` returns a sequence of header
+   tuples that will set a ``paste.auth.auth_tkt`` authentication
+   cookie in the user's browser for the login ``'editor'``.
+
+#. The ``HTTPFound`` exception returns a response that redirects
+   the browser to ``http://localhost:6543/FrontPage/edit_page``,
+   including the headers that set the authentication cookie.
+
+Cycle 3:
+
+#. Route pattern ``'/{pagename}/edit_page'`` matches this URL,
+   but the corresponding view is restricted by an ``'edit'``
+   permission.
+   
+#. Because the user now has an authentication cookie defining
+   their login name as ``'editor'``, the ``groupfinder`` function
+   is called with that value as its ``userid`` argument.
+
+#. The ``groupfinder`` function returns the list
+   ``['group:editors']``.  This satisfies the access control
+   entry ``(Allow, 'group:editors', 'edit')``, which grants the
+   ``edit`` permission.  Thus, this route matches, and control
+   passes to view callable ``edit_page``.
+
+#. Within ``edit_page``, ``name`` is set to ``'FrontPage'``, the
+   page name from ``request.matchdict['pagename']``, and
+   ``page`` is set to an instance of :class:`models.Page`
+   that holds the current content of ``FrontPage``.
+
+#. Since this request did not come from a form,
+   ``request.params`` does not have a key for
+   ``'form.submitted'``.
+
+#. The ``edit_page`` function calls
+   :meth:`pyramid.security.authenticated_userid` to find out
+   whether the user is authenticated.  Because of the cookies
+   set previously, the variable ``logged_in`` is set to
+   the userid ``'editor'``.
+
+#. The ``edit_page`` function returns this dictionary::
+
+    {'page':page, 'logged_in':'editor',
+     'save_url':'http://localhost:6543/FrontPage/edit_page'}
+
+#. Template :file:`edit.pt` is rendered with those values.
+   Among other features of this template, these lines
+   cause the inclusion of a :guilabel:`Logout` link::
+
+      <span tal:condition="logged_in">
+        <a href="${request.application_url}/logout">Logout</a>
+      </span>
+
+   For the example case, this link will refer to
+   ``http://localhost:6543/logout``.
+
+   These lines of the template display the current page's
+   content in a form whose ``action`` attribute is
+   ``http://localhost:6543/FrontPage/edit_page``::
+
+      <form action="${save_url}" method="post">
+        <textarea name="body" tal:content="page.data" rows="10" cols="60"/>
+        <input type="submit" name="form.submitted" value="Save"/>
+      </form>
+
+Cycle 4:
+
+#. The user edits the page content and clicks
+   :guilabel:`Save`.
+
+#. URL ``http://localhost:6543/FrontPage/edit_page`` goes through
+   the same routing as before, up until the line that checks
+   whether ``request.params`` has a key ``'form.submitted'``.
+   This time, within the ``edit_page`` view callable, these
+   lines are executed::
+    
+        page.data = request.params['body']
+        session.add(page)
+        return HTTPFound(location = route_url('view_page', request,
+                                              pagename=name))
+
+   The first two lines replace the old page content with the
+   contents of the ``body`` text area from the form, and then
+   update the page stored in the database.  The third line
+   causes a response that redirects the browser to
+   ``http://localhost:6543/FrontPage``.
+
+.. _revisit:
+
+Revisiting after authentication
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In this case, the user has an authentication cookie set in their
+browser that specifies their login as ``'editor'``.  The
+requested URL is ``http://localhost:6543/FrontPage/edit_page``.
+   
+This process requires two request/response cycles.
+
+1. The user clicks :guilabel:`Edit page`.  The view callable is
+   ``views.edit_page``.  The response is ``edit.pt``, showing
+   the current page content.   
+
+2. The user edits the content and clicks :guilabel:`Save`.
+   The view callable is ``views.edit_page``.  The response is
+   a redirect to ``/Frontpage``.
+
+Cycle 1:
+
+#. The route with pattern ``/{pagename}/edit_page`` matches the
+   URL, and because of the authentication cookie, ``groupfinder``
+   returns a list containing the ``group:editors`` principal,
+   which ``models.RootFactory.__acl__`` uses to grant the
+   ``edit`` permission, so this route matches and dispatches
+   to the view callable :meth:`views.edit_page`.
+
+#. In ``edit_page``, because the request did not come from a form
+   submission, ``request.params`` has no key for
+   ``'form.submitted'``.
+
+#. The variable ``logged_in`` is set to  the login name
+   ``'editor'`` by calling ``authenticated_userid``, which
+   extracts it from the authentication cookie.
+
+#. The function returns this dictionary::
+
+    {'page':page,
+     'save_url':'http://localhost:6543/FrontPage/edit_page',
+     'logged_in':'editor'}
+
+#. Template :file:`edit.pt` is rendered with the values from
+   that dictionary.  Because of the presence of the
+   ``'logged_in'`` entry, a :guilabel:`Logout` link appears.
+
+Cycle 2:
+
+#. The user edits the page content and clicks :guilabel:`Save`.
+
+#. The ``POST`` operation works as in :ref:`good_login`.
+
+.. _logging_out:
+
+Logging out
+~~~~~~~~~~~
+
+This process starts with a request URL
+``http://localhost:6543/logout``.
+
+#. The route with pattern ``'/logout'`` matches and dispatches
+   to the view callable ``logout`` in :file:`login.py`.
+
+#. The call to :meth:`pyramid.security.forget` returns a list of
+   header tuples that will, when returned with the response,
+   cause the browser to delete the user's authentication cookie.
+
+#. The view callable returns an ``HTTPFound`` exception that
+   redirects the browser to named route ``view_wiki``, which
+   will translate to URL ``http://localhost:6543``.  It
+   also passes along the headers that delete the
+   authentication cookie.

--- a/zeo.rst
+++ b/zeo.rst
@@ -1,0 +1,238 @@
+.. _zodb_with_zeo:
+
+Using ZODB with ZEO
+===================
+
+:term:`ZODB` is a Python object persistence mechanism.  :term:`ZODB`
+works well as a storage mechanism for :app:`Pyramid` applications,
+especially in applications that use :term:`traversal`.
+
+:term:`ZEO` is an extension to ZODB which allows more than one process
+to simultaneously communicate with a ZODB storage.  Making a ZODB
+database accessible to more than one process means that you can debug
+your application objects at the same time that a :app:`Pyramid`
+server that accesses the database is running, and will also allow your
+application to run under multiprocess configurations, such as those
+exposed by :term:`mod_wsgi`.
+
+The easiest way to get started with ZODB in a :app:`Pyramid` application is
+to use the ZODB ``pyramid_zodb`` paster template.  See
+:ref:`additional_paster_templates` for more information about using this
+template.  However, the Paster template does not set up a ZEO-capable
+application.  This chapter shows you how to do that "from scratch".
+
+Installing Dependencies
+-----------------------
+
+#. Edit your :app:`Pyramid` application's ``setup.py`` file, adding
+   the following packages to the ``install_requires`` of the
+   application:
+
+   - ``repoze.folder``
+
+   - ``repoze.retry``
+
+   - ``repoze.tm2``
+
+   - ``repoze.zodbconn``
+
+   For example, the relevant portion of your application's
+   ``setup.py`` file might look like so when you're finished adding
+   the dependencies.
+
+   .. code-block:: python
+      :linenos:
+
+      setup(
+          # ... other elements left out for brevity
+          install_requires=[
+                'pyramid',
+                'repoze.folder',
+                'repoze.retry',
+                'repoze.tm2',
+                'repoze.zodbconn',
+                ],
+          # ... other elements left out for brevity
+           )
+
+#. Rerun your application's ``setup.py`` file (e.g. using ``python
+   setup.py develop``) to get these packages installed.  A number of
+   packages will be installed, including ``ZODB``.  For the purposes
+   of this tutorial, we'll assume that your "application" is actually
+   just the result of the ``pyramid_starter`` Paster template.
+
+Configuration
+-------------
+
+#. Edit your application's Paste ``development.ini`` file.
+
+   If you already have an ``app`` section in the ``.ini`` file named
+   ``main``, rename this section to ``myapp`` (e.g. ``app:main`` ->
+   ``app:myapp``).  Add a key to it named ``zodb_uri``, e.g.
+
+   .. code-block:: ini
+
+      [app:myapp]
+      use = egg:myapp#app
+      zodb_uri = zeo://%(here)s/zeo.sock
+      reload_templates = true
+      debug_authorization = false
+      debug_notfound = false
+
+   If a ``pipeline`` named ``main`` does not already exist in the
+   paste ``.ini`` file , add a ``pipeline`` section named ``main``.
+   Put the names ``connector``, ``egg:repoze.retry#retry``, and
+   ``egg:repoze.tm2#tm`` to the top of the pipeline.
+
+   .. code-block:: ini
+
+      [pipeline:main]
+      pipeline = 
+             egg:repoze.retry#retry
+             egg:repoze.tm2#tm
+             myapp
+
+   When you're finished, your ``.ini`` file might look like so:
+
+   .. code-block:: ini
+
+      [DEFAULT]
+      debug = true
+
+      [app:myapp]
+      use = egg:myapp#app
+      zodb_uri = zeo://%(here)s/zeo.sock
+      reload_templates = true
+      debug_authorization = false
+      debug_notfound = false
+
+      [pipeline:main]
+      pipeline = 
+             egg:repoze.retry#retry
+             egg:repoze.tm2#tm
+             myapp
+
+      [server:main]
+      use = egg:Paste#http
+      host = 0.0.0.0
+      port = 6543
+
+   See :ref:`MyProject_ini` for more information about project Paste
+   ``.ini`` files.
+
+#. Add a ``zeo.conf`` file to your package with the following
+   contents:
+
+   .. code-block:: text
+
+      %define INSTANCE .
+
+      <zeo>
+        address $INSTANCE/zeo.sock
+        read-only false
+        invalidation-queue-size 100
+        pid-filename $INSTANCE/zeo.pid
+      </zeo>
+
+      <blobstorage 1>
+        <filestorage>
+          path $INSTANCE/myapp.db
+        </filestorage>
+        blob-dir $INSTANCE/blobs
+      </blobstorage>
+
+#.  For the purposes of this tutorial we'll assume that you want your
+    :app:`Pyramid` application's :term:`root` object to be a
+    "folderish" object.  To achieve this, change your application's
+    ``models.py`` file to look like the below:
+
+    .. code-block:: python
+
+       from repoze.folder import Folder
+
+       class MyModel(Folder):
+           pass
+
+       def appmaker(root):
+           if not 'myapp' in root:
+               root['myapp'] = MyModel()
+               transaction.commit()
+           return root['myapp']
+
+#.  Change your application's ``__init__.py`` to look something like the
+    below:
+
+    .. code-block:: python
+
+       from pyramid.config import Configurator
+       from repoze.zodbconn.finder import PersistentApplicationFinder
+       from myapp.models import appmaker
+       import transaction
+
+       def app(global_config, **settings):
+           """ This function returns a ``pyramid`` WSGI 
+           application.
+
+           It is usually called by the PasteDeploy framework during
+           ``paster serve``"""
+           # paster app config callback
+           zodb_uri = settings['zodb_uri']
+           finder = PersistentApplicationFinder(zodb_uri, appmaker)
+           def get_root(request):
+               return finder(request.environ)
+           config = Configurator(root_factory=get_root, settings=settings)
+           # .. other configuration statements ..
+           return config.make_wsgi_app()
+
+Running
+-------
+    
+#.  Start the ZEO server in a terminal with the current directory set
+    to the package directory:
+
+    .. code-block:: text
+
+       ../bin/runzeo -C zeo.conf
+
+    You should see something like this, as a result:
+
+    .. code-block:: text
+       :linenos:
+
+       [chrism@snowpro myapp]$ ../bin/runzeo -C zeo.conf 
+       ------
+       2009-09-19T13:48:41 INFO ZEO.runzeo (9910) created PID file './zeo.pid'
+       # ... more output ...
+       2009-09-19T13:48:41 INFO ZEO.zrpc (9910) listening on ./zeo.sock
+
+#.  While the ZEO server is running, start the application server:
+
+    .. code-block:: text
+       :linenos:
+
+       [chrism@snowpro myapp]$ ../bin/paster serve myapp.ini 
+       Starting server in PID 10177.
+       serving on 0.0.0.0:6543 view at http://127.0.0.1:6543
+
+#.  The root object is now a "folderish" ZODB object.  Nothing else
+    about the application has changed.  
+
+#.  You can manipulate the database directly (even when the
+    application's HTTP server is running) by using the ``pshell``
+    command in a third terminal window:
+
+    .. code-block:: text
+       :linenos:
+
+       [chrism@snowpro sess]$ ../bin/paster pshell \
+              myapp.ini myapp
+       Python 2.5.4 (r254:67916, Sep  4 2009, 02:12:16) 
+       [GCC 4.2.1 (Apple Inc. build 5646)] on darwin
+       Type "help" for more information. "root" is the Pyramid app root.
+       >>> root
+       <sess.models.MyModel object None at 0x16438f0>
+       >>> root.foo = 'bar'
+       >>> import transaction
+       >>> transaction.commit()
+
+


### PR DESCRIPTION
Moved all the tutorials from the pyramid_tutorials project to have them located in one place and removed from main diocs page.
