### PR TITLE
Fix broken github path for virtualenv-burrito.

### DIFF
--- a/mac_install.rst
+++ b/mac_install.rst
@@ -93,7 +93,7 @@ virtualenvwrapper_ for you. [#]_
 Execute the following commands in Terminal::
 
   cd ~
-  curl -s https://github.com/brainsik/virtualenv-burrito/raw/master/virtualenv-burrito.sh | bash
+  curl -s https://raw.github.com/brainsik/virtualenv-burrito/master/virtualenv-burrito.sh | bash
 
 If successful, you will see this::
 


### PR DESCRIPTION
Just went through this cookbook recipe. The github path no longer works as documented, that page is now a redirect that doesn't work when exercised via curl (as the cookbook recipe dictates). This change simply updates the github url for virtualenv-burrito.
