### PR TITLE
add link to pyramid_apex project which allows for basic or any velruse based authentication

### DIFF
--- a/authentication.rst
+++ b/authentication.rst
@@ -239,10 +239,13 @@ Pyramid Auth with Akhet and SQLAlchemy
 Learn how to set up Pyramid authorization using Akhet and SQLAlchemy at
 http://pyramid.chromaticleaves.com/simpleauth/
 
-Google Authentication
----------------------
+Google, Facebook, Tweeter, and any OpenID Authentication
+-----------------------------------------------------------------
 
 See `Wayne Witzel III's blog post
 <http://pieceofpy.com/blog/2011/07/24/pyramid-and-velruse-for-google-authentication/>`_
 about using Velruse and Pyramid together to do Google OAuth authentication.
 
+See Matthew Housden and Charles Davies pyramid_apex project for any basic and openid
+authentication such as Google, Facebook, Tweeter and more at 
+https://github.com/cd34/pyramid_apex.


### PR DESCRIPTION
add link to pyramid_apex project which allows for basic or any velruse basic authentication.
