### PR TITLE
Fixed section formatting in auth cookbook

### DIFF
--- a/authentication.rst
+++ b/authentication.rst
@@ -235,6 +235,7 @@ Use it something like:
                  authentication_policy=BasicAuthenticationPolicy(mycheck))
 
 Pyramid Auth with Akhet and SQLAlchemy
+--------------------------------------
 
 Learn how to set up Pyramid authorization using Akhet and SQLAlchemy at
 http://pyramid.chromaticleaves.com/simpleauth/


### PR DESCRIPTION
The "Pyramid Auth with Akhet and SQLAlchemy" section was missing some title formatting, and was therefore not included in the table of contents.
