### PR TITLE
Fixed order of args in authentication policy callback example

### DIFF
--- a/authentication.rst
+++ b/authentication.rst
@@ -64,7 +64,7 @@ authentication policies.  For example:
 
    from pyramid.authentication import AuthTktAuthenticationPolicy
 
-   def groupfinder(request, userid):
+   def groupfinder(userid, request):
        user = request.user
        if user is not None:
            return [ group.name for group in request.user.groups ]


### PR DESCRIPTION
In the "Making A User Object Available as a Request Attribute" recipe, the order of the arguments in the  "groupfinder" example callback does not match the framework behavior.
