### PR TITLE
Updated supervisor cookbook example to include autorestart by default

### DIFF
--- a/deployment/nginx.rst
+++ b/deployment/nginx.rst
@@ -294,7 +294,7 @@ for a full breakdown of all of the great options provided.
     serverurl=unix://%(here)s/env/supervisor.sock
 
     [program:myapp]
-	autorestart=true
+    autorestart=true
     command=%(here)s/env/bin/paster serve %(here)s/production.ini http_port=50%(process_num)02d
     process_name=%(program_name)s-%(process_num)01d
     numprocs=2


### PR DESCRIPTION
It was suggest by Raydeo that this could possibly be included as the default.  Sorry about the extra commit.  I wasn't sure how to squash them into one commit.
