### PR TITLE
Added notification about PDB issue with terminal input

### DIFF
--- a/debugging.rst
+++ b/debugging.rst
@@ -152,3 +152,16 @@ Huh?
 - Many great resources can be found describing the details of using
   pdb.  Try the interactive ``help`` (hit 'h') or a search engine near
   you.
+
+.. note:: There is a well known bug in ``PDB`` in UNIX, when user cannot 
+  see what he is typing in terminal window after any interruption during 
+  ``PDB`` session (it can be caused by ``CTRL-C`` or when the server restarts 
+  automatically). This can be fixed by launching any of this commands in broken 
+  terminal: ``reset``, ``stty sane``. Also one can add one of this commands into
+  ``~/.pdbrc`` file, so they will be launched before ``PDB`` session:
+    .. code-block:: python
+
+          from subprocess import Popen
+          Popen(["stty", "sane"])
+
+


### PR DESCRIPTION
We have just discussed PDB issue with terminal here: https://github.com/Pylons/pyramid/issues/689
I think it would be great to let beginners know about it, so they will not have to restart their terminals all the time.

I have added edited version of the source code which I have found in best answer here:
http://stackoverflow.com/questions/2735828/is-there-anyway-to-get-pdb-and-mac-terminal-to-play-nicely
It will launch `stty sane` command each time PDB starts - not bad workaround in our hopeless case IMO.

I'm sorry, my English is bad and my knowledge of .rst markup is even worse :) It's up to you - to use this text, ignore it, or maybe edit like it should be and add to docs.

Just wanted to help, thanks.
