### PR TITLE
some improvements to auth/user_object.rst

### DIFF
--- a/auth/user_object.rst
+++ b/auth/user_object.rst
@@ -3,9 +3,10 @@
 Making A "User Object" Available as a Request Attribute
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-This is you: your application wants a "user object".  Pyramid is only willing
-to supply you with a user *id* (via
-``pyramid.security.authenticated_userid``). You don't want to create a
+This is you: your application wants a "user object".
+Pyramid is only willing to supply you with a user *id*
+(via :meth:`pyramid.security.authenticated_userid`).
+You don't want to create a
 function that accepts a request object and returns a user object from
 your domain model for efficiency reasons, and you want the user object to be
 omnipresent as ``request.user``.
@@ -15,7 +16,9 @@ request, but the ``NewRequest`` susbcriber is called on every request, even
 ones for static resources, and this bothers you (which it should).
 
 A lazy property can be registered to the request via the
-``Configurator.add_request_method`` API. This allows you to specify a
+:meth:`pyramid.config.Configurator.add_request_method` API
+(introduced in Pyramid 1.4; see below for older releases).
+This allows you to specify a
 callable that will be available on the request object, but will not actually
 execute the function until accessed. The result of this function can also
 be cached per-request, to eliminate the overhead of running the function
@@ -38,17 +41,9 @@ multiple times (this is done by setting ``reify=True``.
            # in the database
            return dbconn['users'].query({'id':userid})
 
-Here's how you should add your new request property in configuration code:
-
-.. code-block:: python
-   :linenos:
+Here's how you should add your new request property in configuration code::
 
    config.add_request_method(get_user, 'user', reify=True)
-
-.. note::
-
-   ``Configurator.add_request_method`` has been available since Pyramid 1.4.
-   Check below for older releases.   
 
 Then in your view code, you should be able to happily do ``request.user`` to
 obtain the "user object" related to that request.  It will return ``None`` if
@@ -78,23 +73,18 @@ authentication policies.  For example:
 Prior to Pyramid 1.4
 ====================
 
-If you are using version 1.3, you can use the same method as above, except
-use this instead of ``add_request_method``
-
-.. code-block:: python
-   :linenos:
+If you are using version 1.3, you can follow the same procedure as above,
+except use this instead of ``add_request_method``::
 
    config.set_request_property(get_user, 'user', reify=True)
 
-.. note::
-
-   ``Configurator.set_request_property`` was introduced in Pyramid 1.3 and
-   is docs-deprecated as of Pyramid 1.4.
+.. deprecated:: 1.4
+   :meth:`~pyramid.config.Configurator.set_request_property`
 
 Prior to ``set_request_property`` and ``add_request_method``,
-a similar pattern could be used but it required :ref:`registering
+a similar pattern could be used, but it required :ref:`registering
 a new request factory <changing_the_request_factory>`
-via ``Configurator.set_request_factory``. This works
+via :meth:`~pyramid.config.Configurator.set_request_factory`. This works
 in the same way, but each application can only have one request factory
 and so it is not very extensible for arbitrary properties.
 
@@ -119,9 +109,6 @@ The code for this method is below:
                 # in the database
                 return dbconn['users'].query({'id':userid})
 
-Here's how you should use your new request factory in configuration code:
-
-.. code-block:: python
-   :linenos:
+Here's how you should use your new request factory in configuration code::
 
    config.set_request_factory(RequestWithUserAttribute)

--- a/pylons/exceptions.rst
+++ b/pylons/exceptions.rst
@@ -42,7 +42,7 @@ Exception rules:
    and look for an "exception view" that matches it.  An exception view is one
    whose *context* argument is the exception's class, an ancestor of it, or an
    interface it implements.  All other view predicates must also match;
-   e.g., if a 'route_name' argument is specified it must match the actual route
+   e.g., if a 'route_name' argument is specified, it must match the actual route
    name. (Thus an exception view is typically registered *without* a route
    name.) The view is called with the exception object as its *context*, and
    whatever response the view returns will be sent to the browser. You can thus


### PR DESCRIPTION
- take advantage of intersphinx... add 'free' links to Pyramid docs
- mention availability of the new method earlier
- displaying linenos for 1-liners is overkill
- no need to ask for Python highlighting; it's automatic
- use the more specific 'deprecated' directive, instead of the more
  generic 'note' directive
- add a missing comma (also to pylons/exceptions.rst)
