### PR TITLE
Fixed spelling of HTTPInternalServerError

### DIFF
--- a/pylons/exceptions.rst
+++ b/pylons/exceptions.rst
@@ -22,7 +22,7 @@ Here's how to send redirects and HTTP errors in Pyramid compared to Pylons::
     return exc.HTTPNotFound()           # Same thing
     raise exc.HTTPForbidden()
     raise exc.HTTPBadRequest()
-    raise exc.HTTPInernalServerError()
+    raise exc.HTTPInternalServerError()
     raise exc.HTTPFound(request.route_url("section1"))   # Redirect
 
 The ``pyramid.httpexceptions`` module has classes for all official HTTP


### PR DESCRIPTION
I noticed that HTTPInternalServerError was missing the 't' in Internal.
