### PR TITLE
add intersphinx_mapping to CPython docs

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -34,7 +34,11 @@ extensions = [
     'sphinx.ext.intersphinx'
     ]
 
-intersphinx_mapping = {'http://docs.pylonsproject.org/projects/pyramid/en/latest/': None}
+intersphinx_mapping = {
+     'python': ('http://docs.python.org', None),
+     'python3': ('http://docs.python.org/3', None),
+     'pyramid': ('http://docs.pylonsproject.org/projects/pyramid/en/latest', None),
+}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/index.rst
+++ b/index.rst
@@ -26,7 +26,7 @@ It supplements the `main documentation
    misc/index
    todo
 
-:ref:`Pyramid Glossary <glossary>`
+:ref:`Pyramid Glossary <pyramid:glossary>`
 
 Indices and tables
 ==================


### PR DESCRIPTION
...then ensure the glossary keeps pointing to where intended
