### PR TITLE
Don't pass --distribute to bootstrap.py

### DIFF
--- a/deployment/gae_buildout.rst
+++ b/deployment/gae_buildout.rst
@@ -96,7 +96,7 @@ commands.
 .. code-block:: text
 
    ~/ $ cd newproject
-   ~/newproject $ /usr/bin/python2.7 bootstrap.py --distribute
+   ~/newproject $ /usr/bin/python2.7 bootstrap.py
 
 You typically only need to do this once to generate your
 buildout command. See the `buildout documentation <http://www.buildout.org/docs/tutorial.html#buildout-steps>`_ for more information.


### PR DESCRIPTION
Distribute was merged back into setuptools.  Newer versions of bootstrap.py do not recognize the --distribute option any more.
