### PR TITLE
Update gae_buildout.rst

### DIFF
--- a/deployment/gae_buildout.rst
+++ b/deployment/gae_buildout.rst
@@ -47,6 +47,7 @@ create a virtual environment
 .. code-block:: text
 
    $ virtualenv -p /usr/bin/python2.7 --no-site-packages --distribute myenv
+   $ myenv/bin/pip install buildout
 
 
 install pyramid_appengine into your virtual environment


### PR DESCRIPTION
The following error occurs in ubuntu 13.10:

$ ./bin/buildout 
An internal error occurred due to a bug in either zc.buildout or in a
recipe being used:
Traceback (most recent call last):
  File "/home/jared/ENV/cyber/py27/ca/eggs/zc.buildout-2.2.1-py2.7.egg/zc/buildout/buildout.py", line 1942, in main
    getattr(buildout, command)(args)
  File "/home/jared/ENV/cyber/py27/ca/eggs/zc.buildout-2.2.1-py2.7.egg/zc/buildout/buildout.py", line 622, in install
    installed_files = self[part]._call(recipe.install)
  File "/home/jared/ENV/cyber/py27/ca/eggs/zc.buildout-2.2.1-py2.7.egg/zc/buildout/buildout.py", line 1366, in _call
    return f()
  File "/home/jared/ENV/cyber/py27/ca/eggs/rod.recipe.appengine-2.0.2-py2.7.egg/rod/recipe/appengine/__init__.py", line 367, in install
    self.copy_packages(ws, temp_dir)
  File "/home/jared/ENV/cyber/py27/ca/eggs/rod.recipe.appengine-2.0.2-py2.7.egg/rod/recipe/appengine/**init**.py", line 274, in copy_packages
    self.write_pkg_resources(ws, lib)
  File "/home/jared/ENV/cyber/py27/ca/eggs/rod.recipe.appengine-2.0.2-py2.7.egg/rod/recipe/appengine/**init**.py", line 257, in write_pkg_resources
    assert len(setuptools_eggs) == 1, "setuptools not found"
AssertionError: setuptools not found

If you use the virtual environment instead then bin/buildout runs cleanly.
