### PR TITLE
Fix invocations of "git submodule".

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -111,10 +111,11 @@ if 'sphinx-build' in ' '.join(sys.argv): # protect against dumb importers
     _themes = os.path.join(cwd, '_themes')
     p = Popen('which git', shell=True, stdout=PIPE)
     git = p.stdout.read().strip()
+
     if not os.listdir(_themes):
-        call([git, 'submodule', '--init'])
-    else:
-        call([git, 'submodule', 'update'])
+        call([git, 'submodule', 'init'])
+
+    call([git, 'submodule', 'update'])
 
 # Add and use Pylons theme
 sys.path.append(os.path.abspath('_themes'))


### PR DESCRIPTION
Before my change, I cloned the repo and typed "make singlehtml" in the top level; that generated this bad-looking output:

```
make singlehtml
sphinx-build -b singlehtml -d _build/doctrees  -W . _build/singlehtml
Making output directory...
Running Sphinx v1.1.3
usage: git submodule [--quiet] add [-b <branch>] [-f|--force] [--name <name>] [--reference <repository>] [--] <repository> [<path>]
   or: git submodule [--quiet] status [--cached] [--recursive] [--] [<path>...]
   or: git submodule [--quiet] init [--] [<path>...]
   or: git submodule [--quiet] deinit [-f|--force] [--] <path>...
   or: git submodule [--quiet] update [--init] [--remote] [-N|--no-fetch] [-f|--force] [--rebase] [--reference <repository>] [--merge] [--recursive] [--] [<path>...]
   or: git submodule [--quiet] summary [--cached|--files] [--summary-limit <n>] [commit] [--] [<path>...]
   or: git submodule [--quiet] foreach [--recursive] <command>
   or: git submodule [--quiet] sync [--recursive] [--] [<path>...]
loading pickled environment... not yet created
```

...

```
preparing documents... 
Theme error:
unsupported theme option 'github_url' given
make: *** [singlehtml] Error 1
```
