### PR TITLE
Python 3 import error in mongodb.rst example

### DIFF
--- a/database/mongodb.rst
+++ b/database/mongodb.rst
@@ -22,8 +22,14 @@ attached to each new request::
 
    from pyramid.config import Configurator
 
+   try:
+       # for python 2
+       from urlparse import urlparse
+   except ImportError:
+       # for python 3
+       from urllib.parse import urlparse
+
    from gridfs import GridFS
-   from urlparse import urlparse
    import pymongo
 
 


### PR DESCRIPTION
The urlparse module has been reorganized in Python 3 and therefore leads to an import error in the example "**init**.py" file.
