### PR TITLE
Note about extractor options

### DIFF
--- a/templates/mako_i18n.rst
+++ b/templates/mako_i18n.rst
@@ -106,3 +106,10 @@ setup.py so that Babel can use it when invoking it's commands)::
        ...
        )
 
+In the above triples the last element, ``None`` in this snippet, may be used
+to pass an options dictionary to the specified extractor. For instance, you may
+need to set Mako input encoding using the corresponding option::
+    
+    ...
+               ('templates/**.mako', 'mako', {'input_encoding': 'utf-8'}),
+    ...


### PR DESCRIPTION
I tried following the recipe and got a Unicode error during message extraction because Mako was using 'ascii' codec. Specifying the input encoding explicitly fixed the issue, so I decided to add a note about this.
