### PR TITLE
Improve & extend cookbook recipe

### DIFF
--- a/testing/testing_post_curl.rst
+++ b/testing/testing_post_curl.rst
@@ -1,56 +1,127 @@
-Testing a POST Request Using cURL
+Testing a POST request using cURL
 ---------------------------------
 
 Using the following Pyramid application::
 
+    from wsgiref.simple_server import make_server
     from pyramid.view import view_config
-
-    @view_config(route_name='theroute', renderer='string', 
+    from pyramid.config import Configurator
+    
+    @view_config(route_name='theroute', renderer='json', 
                  request_method='POST')
     def myview(request):
-        print request.GET.items()
-        print request.POST.items()
-        print request.params.items()
-        return 'OK'
+        return {'POST': request.POST.items()}
         
     if __name__ == '__main__':
-        from pyramid.config import Configurator
-        from paste.httpserver import serve
         config = Configurator()
         config.add_route('theroute', '/')
-        config.scan('__main__')
-        serve(config.make_wsgi_app())
+        config.scan()
+        app = config.make_wsgi_app()
+        server = make_server('0.0.0.0', 6543, app)
+        print server.base_environ
+        server.serve_forever()
 
-Once your run the above application, you can test a POST request to the
-application via ``curl`` (available on most UNIX systems):
-
-.. code-block:: text
-
-   $ curl -d "param1=value1&param2=value2" http://localhost:8080/?param3=value3
-
-You'll see the following output on the application terminal:
+Once you run the above application, you can test a POST request to the
+application via ``curl`` (available on most UNIX systems).
 
 .. code-block:: text
 
-    [('param3', u'value3')]
-    [('param1', u'value1'), ('param2', u'value2')]
-    [('param3', u'value3'), ('param1', u'value1'), ('param2', u'value2')]
+    $ python application.py 
+    {'CONTENT_LENGTH': '', 'SERVER_NAME': 'Latitude-XT2', 'GATEWAY_INTERFACE': 'CGI/1.1',
+     'SCRIPT_NAME': '', 'SERVER_PORT': '6543', 'REMOTE_HOST': ''}
+    
 
-Note the relationship between the query string and ``request.GET``.  Note the
-relationship between the POST body values (provided as the argument to the
-``-d`` flag of ``curl``) and ``request.POST``.  Note that ``request.params``
-is an amalgamation of ``request.GET`` and ``request.POST`` values.
+To access POST request body values (provided as the argument to the
+``-d`` flag of ``curl``) use ``request.POST``.
 
-For bonus points, here's a simple Python program that will do the same as the
-``curl`` command above does::
+.. code-block:: text
 
-    import httplib, urllib
-    params = urllib.urlencode({'param1': 'value1', 'param2': 'value2'})
-    headers = {"Content-type": "application/x-www-form-urlencoded",
-               "Accept": "text/plain"}
-    conn = httplib.HTTPConnection("localhost:8080")
-    conn.request("POST", "/?param3=value3", params, headers)
-    response = conn.getresponse()
-    print response.status, response.reason
-    data = response.read()
-    conn.close()
+    $ curl -i -d "param1=value1&param2=value2" http://localhost:6543/
+    HTTP/1.0 200 OK
+    Date: Tue, 09 Sep 2014 09:34:27 GMT
+    Server: WSGIServer/0.1 Python/2.7.5+
+    Content-Type: application/json; charset=UTF-8
+    Content-Length: 54
+    
+    {"POST": [["param1", "value1"], ["param2", "value2"]]}
+
+
+To access QUERY_STRING parameters as well, use ``request.GET``.
+
+.. code-block:: python
+
+    @view_config(route_name='theroute', renderer='json', 
+                 request_method='POST')
+    def myview(request):
+        return {'GET':request.GET.items(),
+                'POST':request.POST.items()}
+
+
+Append QUERY_STRING parameters to previously used URL and query with curl.
+
+.. code-block:: text
+
+    $ curl -i -d "param1=value1&param2=value2" http://localhost:6543/?param3=value3
+    HTTP/1.0 200 OK
+    Date: Tue, 09 Sep 2014 09:39:53 GMT
+    Server: WSGIServer/0.1 Python/2.7.5+
+    Content-Type: application/json; charset=UTF-8
+    Content-Length: 85
+    
+    {"POST": [["param1", "value1"], ["param2", "value2"]], "GET": [["param3", "value3"]]}
+
+
+
+Use ``request.params`` to have access to dictionary-like object
+containing both the parameters from the query string and request body.
+
+.. code-block:: python
+
+    @view_config(route_name='theroute', renderer='json', 
+                 request_method='POST')
+    def myview(request):
+        return {'GET':request.GET.items(),
+                'POST':request.POST.items(),
+                'PARAMS':request.params.items()}
+
+
+Another request with curl.
+
+.. code-block:: text
+
+    $ curl -i -d "param1=value1&param2=value2" http://localhost:6543/?param3=value3
+    HTTP/1.0 200 OK
+    Date: Tue, 09 Sep 2014 09:53:16 GMT
+    Server: WSGIServer/0.1 Python/2.7.5+
+    Content-Type: application/json; charset=UTF-8
+    Content-Length: 163
+    
+    {"POST": [["param1", "value1"], ["param2", "value2"]],
+     "PARAMS": [["param3", "value3"], ["param1", "value1"], ["param2", "value2"]], 
+     "GET": [["param3", "value3"]]}
+    
+
+Here's a simple Python program that will do the same as the ``curl`` command above does.
+
+.. code-block:: python
+
+    import httplib
+    import urllib
+    from contextlib import closing
+    
+    with closing(httplib.HTTPConnection("localhost", 6543)) as conn:
+    	headers = {"Content-type": "application/x-www-form-urlencoded"}
+    	params = urllib.urlencode({'param1': 'value1', 'param2': 'value2'})
+    	conn.request("POST", "?param3=value3", params, headers)
+    	response = conn.getresponse()
+    	print response.getheaders()
+    	print response.read()
+
+
+Running this program on a console.
+
+.. code-block:: text
+
+    $ python request.py 
+    [('date', 'Tue, 09 Sep 2014 10:18:46 GMT'), ('content-length', '163'), ('content-type', 'application/json; charset=UTF-8'), ('server', 'WSGIServer/0.1 Python/2.7.5+')]
+    {"POST": [["param2", "value2"], ["param1", "value1"]], "PARAMS": [["param3", "value3"], ["param2", "value2"], ["param1", "value1"]], "GET": [["param3", "value3"]]}


### PR DESCRIPTION
Use wsgiref server since we use a single file application and not a scaffold that installs paste as a dependency. Explain step-by-step. Switch from print statements to JSON responses to keep the reader more focused to aspects of HTTP from curl and python calls. Slightly improve python program using a context manager and print response headers to have the response just like we have seen from curl.