### PR TITLE
Fixed hyperlink in database/sqlalchemy.rst

### DIFF
--- a/database/sqlalchemy.rst
+++ b/database/sqlalchemy.rst
@@ -170,7 +170,6 @@ imported without requiring that you import each "by hand" within
 Writing Tests For Pyramid + SQLAlchemy
 --------------------------------------
 
-John Anderson's blog entry at
-http://sontek.net/writing-tests-for-pyramid-and-sqlalchemy describes a
-strategy for writing tests for systems which integrate Pyramid and
-SQLAlchemy.
+John Anderson's blog entry describes a strategy for
+`writing tests for systems which integrate Pyramid and SQLAlchemy
+<http://www.sontek.net/blog/2011/12/01/writing_tests_for_pyramid_and_sqlalchemy.html>`_.


### PR DESCRIPTION
The blog that is linked to seems to have changed URL structure, as the hyperlink redirects to the homepage.
I have updated the link to point to the individual article again.
