### PR TITLE
Use set -e in run script.

### DIFF
--- a/deployment/heroku.rst
+++ b/deployment/heroku.rst
@@ -58,6 +58,7 @@ Create ``run`` with the following:
 .. code-block:: text
     
     #!/bin/bash
+    set -e
     python setup.py develop
     python runapp.py
 


### PR DESCRIPTION
This means the script will bail with an error code if any step fails, so
heroku notices something went wrong without waiting for the app startup
timeout.