### PR TITLE
Use StringIO.StringIO() instead of io.StringIO()

### DIFF
--- a/templates/customrenderers.rst
+++ b/templates/customrenderers.rst
@@ -13,7 +13,7 @@ application (or anywhere else you'd like to place such things):
 .. code-block:: python
 
    import csv
-   import io
+   import StringIO
 
    class CSVRenderer(object):
       def __init__(self, info):
@@ -31,7 +31,7 @@ application (or anywhere else you'd like to place such things):
             if ct == response.default_content_type:
                response.content_type = 'text/csv'      
          
-         fout = io.StringIO()
+         fout = StringIO.StringIO()
          writer = csv.writer(fout, delimiter=',', quotechar=',', quoting=csv.QUOTE_MINIMAL)
          
          writer.writerow(value.get('header', []))

--- a/templates/customrenderers.rst
+++ b/templates/customrenderers.rst
@@ -14,6 +14,7 @@ application (or anywhere else you'd like to place such things):
 
    import csv
    import StringIO
+   # If on Python 3, import io instead
 
    class CSVRenderer(object):
       def __init__(self, info):
@@ -32,6 +33,8 @@ application (or anywhere else you'd like to place such things):
                response.content_type = 'text/csv'      
          
          fout = StringIO.StringIO()
+         # If on Python 3, use io.StringIO() instead
+         
          writer = csv.writer(fout, delimiter=',', quotechar=',', quoting=csv.QUOTE_MINIMAL)
          
          writer.writerow(value.get('header', []))


### PR DESCRIPTION
io.StringIO() doesn't work with csv in Python 2.7.  Using StringIO.StringIO() fixes this and makes compatible with Python 3 also. 
http://stackoverflow.com/questions/13120127/how-can-i-use-io-stringio-with-the-csv-module