### PR TITLE
Fix argument name in call to Session.configure

### DIFF
--- a/pylons/models.rst
+++ b/pylons/models.rst
@@ -341,7 +341,7 @@ engine arguments that override any same-name ones in the INI file. ::
 At this point you have a choice. Do you want to bind different tables to
 different databases in the same DBSession? That's easy::
 
-    DBSession.configure(bind={models.Person: engine, models.Score: stats})
+    DBSession.configure(binds={models.Person: engine, models.Score: stats})
 
 The keys in the ``binds`` dict can be SQLAlchemy ORM classes, table objects, or
 mapper objects.


### PR DESCRIPTION
The argument that accepts a dict is called "binds", not "bind", as indicated on the following line (just after my proposed change).