### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/docs/database/sqlalchemy.rst
+++ b/docs/database/sqlalchemy.rst
@@ -10,7 +10,7 @@ for more information.
 
 Alternatively, you can try to follow
 :ref:`wiki tutorial <bfg_sql_wiki_tutorial>` or
-`blogr tutorial <http://pyramid-blogr.readthedocs.org>`_.
+`blogr tutorial <http://docs.pylonsproject.org/projects/pyramid-blogr/en/latest/>`_.
 
 Using a Non-Global Session
 --------------------------

--- a/docs/debugging/pydev.rst
+++ b/docs/debugging/pydev.rst
@@ -111,7 +111,7 @@ Running/Debugging Pyramid under Pydev
    ``$WORKSPACE`` is the name of the PyDev workspace containing your project
    
    To create a working example, copy the `pyramid tutorial step03 
-   <https://pyramid_tutorials.readthedocs.org/en/latest/getting_started/03-config/index.html>`_
+   <http://docs.pylonsproject.org/projects/pyramid/en/latest/quick_tutorial/ini.html>`_
    code into $WORKSPACE/tutorial.
    
    After copying the code, cd to ``$WORKSPACE/tutorial`` and run

--- a/docs/links.rst
+++ b/docs/links.rst
@@ -21,20 +21,20 @@
     Note: this isn't working for me with multiword terms with spaces.
 
 
-.. _Pyramid manual: http://docs.pylonsproject.org/projects/pyramid/en/1.3-branch/index.html
-.. _Tutorials: http://docs.pylonsproject.org/projects/pyramid/en/1.3-branch/index.html#tutorials
-.. _Installing Pyramid: http://docs.pylonsproject.org/projects/pyramid/en/1.3-branch/narr/install.html
-.. _Creating a Pyramid Project: http://docs.pylonsproject.org/projects/pyramid/en/1.3-branch/narr/project.html
+.. _Pyramid manual: http://docs.pylonsproject.org/projects/pyramid/en/latest/
+.. _Tutorials: http://docs.pylonsproject.org/projects/pyramid/en/latest/#tutorials
+.. _Installing Pyramid: http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/install.html
+.. _Creating a Pyramid Project: http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/project.html
 
 .. _Akhet:   http://docs.pylonsproject.org/projects/akhet/en/latest/
-.. _Beaker:  http://beaker.readthedocs.org/en/latest/sessions.html
-.. _SQLAlchemy manual:  http://docs.sqlalchemy.org/
-.. _pyramid_handlers:  http://docs.pylonsproject.org/projects/pyramid_handlers/en/latest/
+.. _Beaker:  https://beaker.readthedocs.io/en/latest/sessions.html
+.. _SQLAlchemy manual:  http://docs.sqlalchemy.org/en/latest/
+.. _pyramid_handlers:  http://docs.pylonsproject.org/projects/pyramid-handlers/en/latest/
 .. _pyramid_routehelper:  https://github.com/Pylons/pyramid_routehelper/blob/master/pyramid_routehelper/__init__.py
 
 .. _Deform:  http://docs.pylonsproject.org/projects/deform/en/latest/
-.. _pyramid_simpleform:  http://packages.python.org/pyramid_simpleform/
+.. _pyramid_simpleform:  http://pythonhosted.org/pyramid_simpleform/
 
-.. _Kotti:  http://kotti.readthedocs.org/en/latest/index.html
-.. _Ptah:  http://ptahproject.readthedocs.org/en/latest/index.html
-.. _Khufu: http://pypi.python.org/pypi?%3Aaction=search&term=khufu&submit=search
+.. _Kotti:  https://kotti.readthedocs.io/en/latest/
+.. _Ptah:  https://ptahproject.readthedocs.io/en/latest/
+.. _Khufu: https://github.com/khufuproject

--- a/docs/pylons/static.rst
+++ b/docs/pylons/static.rst
@@ -205,5 +205,5 @@ Of course, if you have the files in the static directory they'll still be
 visible as "/static/robots.txt" as well as "/robots.txt". If that bothers you,
 make another directory outside the static directory for them.
 
-.. _pyramid_assetviews: https://pyramid_assetviews.readthedocs.org/en/latest/
+.. _pyramid_assetviews: https://pyramid-assetviews.readthedocs.io/en/latest/
 

--- a/docs/routing/traversal_sqlalchemy.rst
+++ b/docs/routing/traversal_sqlalchemy.rst
@@ -103,7 +103,7 @@ recursively. Kotti is a content management system that, yes, lets users define
 arbitrarily deep URLs. Specifically, Kotti allows users to define a page with
 subpages; e.g., a "directory" of pages.
 
-.. _Kotti: http://kotti.readthedocs.org/en/latest/index.html
+.. _Kotti: https://kotti.readthedocs.io/en/latest/
 
 Kotti is rather complex and takes some time to study. It uses SQLAlchemy's
 polymorphism to make tables "inherit" from other tables. This is an advanced

--- a/docs/templates/templates.rst
+++ b/docs/templates/templates.rst
@@ -148,7 +148,7 @@ Content inside ``<tal:block metal:fill-slot="content"></tal:block>`` tags
 will replace corresponding block in ``base`` template. You can define
 as many slots in as you want. For more information please see
 `Macro Expansion Template Attribute Language
-<http://chameleon.readthedocs.org/en/latest/reference.html#macros-metal>`_
+<https://chameleon.readthedocs.io/en/latest/reference.html#macros-metal>`_
 documentation.
 
 Using Building Blocks with Chameleon

--- a/docs/testing/index.rst
+++ b/docs/testing/index.rst
@@ -13,4 +13,4 @@ section of the Pyramid documentation.
 For additional information on other testing packages see:
 
 - `WebTest <http://webtest.pythonpaste.org/en/latest/>`_
-- `nose <https://nose.readthedocs.org/en/latest/>`_
+- `nose <https://nose.readthedocs.io/en/latest/>`_


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.