### PR TITLE
Fix linenums on single file to-do-app tutorial

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -116,3 +116,4 @@ Davide Moro, 11/01/2014
 Sergiu Bivol, 09/01/2015
 Rico Moorman, 03/30/2016
 Dan Clark, 03/11/2017
+Benjamin Petersen, 03/20/2017

--- a/docs/sample_applications/single_file_tasks.rst
+++ b/docs/sample_applications/single_file_tasks.rst
@@ -132,7 +132,7 @@ emphasized lines.
    :language: python
    :lines: 1-8
    :linenos:
-   :lineno-start: 1
+   :lineno-match:
    :emphasize-lines: 3,6-8
 
 To make the process of creating the database slightly easier, rather than
@@ -198,8 +198,7 @@ let the application discover and register views:
 .. literalinclude:: single_file_tasks_src/tasks.py
    :language: python
    :lines: 8-11
-   :linenos:
-   :lineno-start: 8
+   :lineno-match:
    :emphasize-lines: 2,4
 
 Note that our imports are sorted alphabetically within the ``pyramid``
@@ -223,8 +222,7 @@ The view function will pass a dictionary defining ``tasks`` to the
 .. literalinclude:: single_file_tasks_src/tasks.py
    :language: python
    :lines: 19-27
-   :linenos:
-   :lineno-start: 19
+   :lineno-match:
    :emphasize-lines: 4-
 
 When using the ``view_config`` decorator, it's important to specify a
@@ -247,8 +245,7 @@ following code immediately after the ``list_view``.
 .. literalinclude:: single_file_tasks_src/tasks.py
    :language: python
    :lines: 30-42
-   :linenos:
-   :lineno-start: 30
+   :lineno-match:
    :emphasize-lines: 1-
 
 .. warning::
@@ -268,8 +265,7 @@ after the ``new_view``.
 .. literalinclude:: single_file_tasks_src/tasks.py
    :language: python
    :lines: 45-52
-   :linenos:
-   :lineno-start: 45
+   :lineno-match:
    :emphasize-lines: 1-
 
 
@@ -285,8 +281,7 @@ subsequent step. Insert the following code immediately after the
 .. literalinclude:: single_file_tasks_src/tasks.py
    :language: python
    :lines: 55-58
-   :linenos:
-   :lineno-start: 55
+   :lineno-match:
    :emphasize-lines: 1-
 
 
@@ -383,8 +378,7 @@ lines as indicated in the following.
 .. literalinclude:: single_file_tasks_src/tasks.py
    :language: python
    :lines: 90-98
-   :linenos:
-   :lineno-start: 90
+   :lineno-match:
    :emphasize-lines: 2,7-8
 
 
@@ -404,8 +398,7 @@ To cause this static file to be served by the application, we must add a
 .. literalinclude:: single_file_tasks_src/tasks.py
    :language: python
    :lines: 101-104
-   :linenos:
-   :lineno-start: 101
+   :lineno-match:
    :emphasize-lines: 2-3
 
 

--- a/docs/sample_applications/single_file_tasks.rst
+++ b/docs/sample_applications/single_file_tasks.rst
@@ -145,7 +145,7 @@ started.
 
 .. literalinclude:: single_file_tasks_src/tasks.py
    :language: python
-   :lines: 73-85
+   :lines: 74-85
    :linenos:
    :lineno-start: 21
    :emphasize-lines: 1-9
@@ -197,10 +197,10 @@ let the application discover and register views:
 
 .. literalinclude:: single_file_tasks_src/tasks.py
    :language: python
-   :lines: 8-12
+   :lines: 8-11
    :linenos:
    :lineno-start: 8
-   :emphasize-lines: 2-3,5
+   :emphasize-lines: 2,4
 
 Note that our imports are sorted alphabetically within the ``pyramid``
 Python-dotted name which makes them easier to find as their number increases.
@@ -222,9 +222,9 @@ The view function will pass a dictionary defining ``tasks`` to the
 
 .. literalinclude:: single_file_tasks_src/tasks.py
    :language: python
-   :lines: 20-28
+   :lines: 19-27
    :linenos:
-   :lineno-start: 20
+   :lineno-start: 19
    :emphasize-lines: 4-
 
 When using the ``view_config`` decorator, it's important to specify a
@@ -246,9 +246,9 @@ following code immediately after the ``list_view``.
 
 .. literalinclude:: single_file_tasks_src/tasks.py
    :language: python
-   :lines: 31-43
+   :lines: 30-42
    :linenos:
-   :lineno-start: 31
+   :lineno-start: 30
    :emphasize-lines: 1-
 
 .. warning::
@@ -267,9 +267,9 @@ after the ``new_view``.
 
 .. literalinclude:: single_file_tasks_src/tasks.py
    :language: python
-   :lines: 46-53
+   :lines: 45-52
    :linenos:
-   :lineno-start: 46
+   :lineno-start: 45
    :emphasize-lines: 1-
 
 
@@ -284,9 +284,9 @@ subsequent step. Insert the following code immediately after the
 
 .. literalinclude:: single_file_tasks_src/tasks.py
    :language: python
-   :lines: 56-58
+   :lines: 55-58
    :linenos:
-   :lineno-start: 56
+   :lineno-start: 55
    :emphasize-lines: 1-
 
 

--- a/docs/sample_applications/single_file_tasks_src/tasks.py
+++ b/docs/sample_applications/single_file_tasks_src/tasks.py
@@ -3,10 +3,9 @@ import logging
 import sqlite3
 
 from pyramid.config import Configurator
+from pyramid.events import ApplicationCreated
 from pyramid.events import NewRequest
 from pyramid.events import subscriber
-from pyramid.events import ApplicationCreated
-from pyramid.exceptions import NotFound
 from pyramid.httpexceptions import HTTPFound
 from pyramid.session import UnencryptedCookieSessionFactoryConfig
 from pyramid.view import view_config
@@ -23,7 +22,7 @@ here = os.path.dirname(os.path.abspath(__file__))
 # views
 @view_config(route_name='list', renderer='list.mako')
 def list_view(request):
-    rs = request.db.execute("select id, name from tasks where closed = 0")
+    rs = request.db.execute('select id, name from tasks where closed = 0')
     tasks = [dict(id=row[0], name=row[1]) for row in rs.fetchall()]
     return {'tasks': tasks}
 
@@ -46,7 +45,7 @@ def new_view(request):
 @view_config(route_name='close')
 def close_view(request):
     task_id = int(request.matchdict['id'])
-    request.db.execute("update tasks set closed = ? where id = ?",
+    request.db.execute('update tasks set closed = ? where id = ?',
                        (1, task_id))
     request.db.commit()
     request.session.flash('Task was successfully closed!')
@@ -66,6 +65,7 @@ def new_request_subscriber(event):
     settings = request.registry.settings
     request.db = sqlite3.connect(settings['db'])
     request.add_finished_callback(close_db_connection)
+
 
 def close_db_connection(request):
     request.db.close()


### PR DESCRIPTION
The main reason for this change is to show line 58, the return of the
`nofound_view`. Without this line, the 404 handler doesn't work and will
raise exceptions in the console that may confuse new users.

Also, removed unused import `NotFound` and tweaked line numbers to match
changes.