### PR TITLE
Logger.warn() is deprecated, use warning()

### DIFF
--- a/docs/sample_applications/single_file_tasks_src/tasks.py
+++ b/docs/sample_applications/single_file_tasks_src/tasks.py
@@ -73,7 +73,7 @@ def close_db_connection(request):
 
 @subscriber(ApplicationCreated)
 def application_created_subscriber(event):
-    log.warn('Initializing database...')
+    log.warning('Initializing database...')
     with open(os.path.join(here, 'schema.sql')) as f:
         stmt = f.read()
         settings = event.app.registry.settings


### PR DESCRIPTION
Excerpt from the python doc: 
There is an obsolete method warn which is functionally identical to warning. As warn is deprecated, please do not use it - use warning instead.
https://docs.python.org/3/library/logging.html