### PR TITLE
Fix typo in BasicAuthAuthenticationPolicy class name

### DIFF
--- a/docs/auth/basic.rst
+++ b/docs/auth/basic.rst
@@ -15,4 +15,4 @@ Use it something like::
        return ['groups', 'that', 'login', 'is', 'member', 'of']
 
    config = Configurator(
-                 authentication_policy=BasicAuthenticationPolicy(mycheck))
+                 authentication_policy=BasicAuthAuthenticationPolicy(mycheck))


### PR DESCRIPTION
Related to https://github.com/Pylons/pyramid/issues/3066