### PR TITLE
Update deploying to App Engine

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -118,3 +118,4 @@ Rico Moorman, 03/30/2016
 Dan Clark, 03/11/2017
 Benjamin Petersen, 03/20/2017
 Volker Diels-Grabsch, 06/08/2017
+Jeremy Davis, 07/09/2017

--- a/docs/deployment/gae.rst
+++ b/docs/deployment/gae.rst
@@ -4,7 +4,7 @@
 ==============================================================
 
 It is possible to run a :app:`Pyramid` application on Google's `App
-Engine <http://code.google.com/appengine/>`_.  This
+Engine <https://cloud.google.com/appengine/>`_.  This
 tutorial is written in terms of using the command line on a UNIX
 system; it should be possible to perform similar actions on a Windows
 system. This tutorial also assumes you've already installed and created a :app:`Pyramid` application,
@@ -13,92 +13,95 @@ and that you have an App Engine account to deploy to.
 Setup
 -----
 
-   First we'll need to create a few files so that App Engine can communicate with our project properly.
+First we'll need to create a few files so that App Engine can communicate with our project properly.
 
-   Create a ``requirements.txt`` file, a ``main.py`` file, an ``app.yaml`` file, and an ``appengine_config.py`` file.
+Create a ``requirements.txt`` file, a ``main.py`` file, an ``app.yaml`` file, and an ``appengine_config.py`` file.
 
 #. Edit ``requirements.txt``
 
-    Add the following lines:
+Add the following lines:
 
-    .. code-block:: text
-        :linenos:
+.. code-block:: text
+    :linenos:
 
-        Pyramid
-        waitress
-        pyramid_debugtoolbar
-        pyramid_chameleon
+    Pyramid
+    waitress
+    pyramid_debugtoolbar
+    pyramid_chameleon
 
 #. Edit ``main.py``
 
-   Add the following lines::
+Add the following lines::
 
-        from pyramid.paster import get_app, setup_logging
-        ini_path = 'production.ini'
-        setup_logging(ini_path)
-        application = get_app(ini_path, 'main')
+.. code-block:: python
+    from pyramid.paster import get_app, setup_logging
+    ini_path = 'production.ini'
+    setup_logging(ini_path)
+    application = get_app(ini_path, 'main')
 
 #. Edit ``appengine_config.py``
 
-   Add the following lines::
+Add the following lines::
 
-        from google.appengine.ext import vendor
-        vendor.add('lib')
+.. code-block:: python
+
+    from google.appengine.ext import vendor
+    vendor.add('lib')
 
 #. Edit ``app.yaml``
 
-   Add the following lines:
+Add the following lines:
 
-    .. code-block:: yaml
+.. code-block:: yaml
 
-        application: application-id
-        version: version
-        runtime: python27
-        api_version: 1
-        threadsafe: false
+    application: application-id
+    version: version
+    runtime: python27
+    api_version: 1
+    threadsafe: false
 
-        handlers:
-        - url: /static
-          static_dir: pyramid_project/static
-        - url: /.*
-          script: main.application
+    handlers:
+    - url: /static
+      static_dir: pyramid_project/static
+    - url: /.*
+      script: main.application
 
-    Replace `application` with your App Engine app ID, `version` with the version you want to deploy to, and `pyramid_project`
-    in the `static_dir` definition with the directory name above your static assets. If your static assets are in the root
-    directory, you can just put `static`
+Replace `application` with your App Engine app ID, `version` with the version you want to deploy to, and `pyramid_project`
+in the `static_dir` definition with the directory name above your static assets. If your static assets are in the root
+directory, you can just put `static`
 
-    For more details about app.yaml, see `app.yaml Reference <https://cloud.google.com/appengine/docs/standard/python/config/appref>`_.
+For more details about app.yaml, see `app.yaml Reference <https://cloud.google.com/appengine/docs/standard/python/config/appref>`_.
 
 
-#. Install dependancies
+#. Install dependencies
 
-    .. code-block:: text
+.. code-block:: bash
 
-      $ pip install -t lib -r requirements.txt
+    $ pip install -t lib -r requirements.txt
 
 
 Running Locally
 ---------------
 
-    At this point you should have everything you need to run your Pyramid application locally using dev_appserver.
-    Assuming you have appengine in your $PATH,
+At this point you should have everything you need to run your Pyramid application locally using dev_appserver.
+Assuming you have appengine in your $PATH,
 
-    .. code-block:: text
+.. code-block:: text
 
-      $ dev_appserver.py app.yaml
+  $ dev_appserver.py app.yaml
 
-    And voilà! You should have a perfectly-running Pyramid application running under Google App Engine, on your local machine.
+And voilà! You should have a perfectly-running Pyramid application running under Google App Engine, on your local machine.
 
 Deploying
 ---------
 
-    Deploying to App Engine is pretty straight forward. If you've successfully launched your application locally,
-    deploying is just as easy.
+Deploying to App Engine is pretty straight forward. If you've successfully launched your application locally,
+deploying is just as easy.
 
-    .. code-block:: text
+.. code-block:: text
 
-      $ appcfg.py update app.yaml
+  $ appcfg.py update app.yaml
 
-    Your Pyramid application is now live to the world! You can access it by navigation to your domain name, or by
-    `applicationid.appspot.com`, or if you've specified a version outside of your default, it would
-    be `version-dot-applicationid.appspot.com`
+Your Pyramid application is now live to the world! You can access it by navigation to your domain name, or by
+`applicationid.appspot.com`, or if you've specified a version outside of your default, it would
+be `version-dot-applicationid.appspot.com`

--- a/docs/deployment/gae.rst
+++ b/docs/deployment/gae.rst
@@ -1,225 +1,104 @@
 .. _appengine_tutorial:
 
-:app:`Pyramid` on Google's App Engine (using appengine-monkey)
+:app:`Pyramid` on Google's App Engine
 ==============================================================
 
-This is but one way to develop applications to run on Google's `App
-Engine <http://code.google.com/appengine/>`_. This one uses
-`appengine-monkey`. For a different approach, you may want to look at
-:ref:`appengine_buildout_tutorial`.
-
 It is possible to run a :app:`Pyramid` application on Google's `App
-Engine <http://code.google.com/appengine/>`_.  Content from this
-tutorial was contributed by YoungKing, based on the
-`"appengine-monkey" tutorial for Pylons
-<http://code.google.com/p/appengine-monkey/wiki/Pylons>`_.  This
+Engine <http://code.google.com/appengine/>`_.  This
 tutorial is written in terms of using the command line on a UNIX
 system; it should be possible to perform similar actions on a Windows
-system.
+system. This tutorial also assumes you've already installed and created a :app:`Pyramid` application,
+and that you have an App Engine account to deploy to.
 
-#. Download Google's `App Engine SDK
-   <http://code.google.com/appengine/downloads.html>`_ and install it
-   on your system.
+Setup
+-----
 
-#. Use Subversion to check out the source code for
-   ``appengine-monkey``.
+   First we'll need to create a few files so that App Engine can communicate with our project properly.
 
-   .. code-block:: text
+   Create a ``requirements.txt`` file, a ``main.py`` file, an ``app.yaml`` file, and an ``appengine_config.py`` file.
 
-      $ svn co http://appengine-monkey.googlecode.com/svn/trunk/ \
-          appengine-monkey
+#. Edit ``requirements.txt``
 
-#. Use ``appengine_homedir.py`` script in ``appengine-monkey`` to
-   create a :term:`virtualenv` for your application.
+    Add the following lines:
 
-   .. code-block:: text
- 
-      $ export GAE_PATH=/usr/local/google_appengine
-      $ python2.5 /path/to/appengine-monkey/appengine-homedir.py --gae \
-        $GAE_PATH pyramidapp
+    .. code-block:: text
+        :linenos:
 
-   Note that ``$GAE_PATH`` should be the path where you have unpacked
-   the App Engine SDK.  (On Mac OS X at least,
-   ``/usr/local/google_appengine`` is indeed where the installer puts
-   it).
+        Pyramid
+        waitress
+        pyramid_debugtoolbar
+        pyramid_chameleon
 
-   This will set up an environment in ``pyramidapp/``, with some tools
-   installed in ``pyramidapp/bin``. There will also be a directory
-   ``pyramidapp/app/`` which is the directory you will upload to
-   appengine.
+#. Edit ``main.py``
 
-#. Install :app:`Pyramid` into the virtualenv
+   Add the following lines::
 
-   .. code-block:: text
+        from pyramid.paster import get_app, setup_logging
+        ini_path = 'production.ini'
+        setup_logging(ini_path)
+        application = get_app(ini_path, 'main')
 
-      $ cd pyramidapp/
-      $ bin/easy_install pyramid
+#. Edit ``appengine_config.py``
 
-   This will install :app:`Pyramid` in the environment.
+   Add the following lines::
 
-#. Create your application
+        from google.appengine.ext import vendor
+        vendor.add('lib')
 
-   We'll use the standard way to create a :app:`Pyramid`
-   application, but we'll have to move some files around when we are
-   done.  The below commands assume your current working directory is
-   the ``pyramidapp`` virtualenv directory you created in the third step
-   above:
+#. Edit ``app.yaml``
 
-   .. code-block:: text
+   Add the following lines:
 
-      $ cd app
-      $ rm -rf pyramidapp
-      $ bin/pcreate -s starter pyramidapp
-      $ mv pyramidapp aside
-      $ mv aside/pyramidapp .
-      $ rm -rf aside
+    .. code-block:: yaml
 
-#. Edit ``config.py``
+        application: application-id
+        version: version
+        runtime: python27
+        api_version: 1
+        threadsafe: false
 
-   Edit the ``APP_NAME`` and ``APP_ARGS`` settings within
-   ``config.py``.  The ``APP_NAME`` must be ``pyramidapp:main``, and
-   the APP_ARGS must be ``({},)``.  Any other settings in
-   ``config.py`` should remain the same::
+        handlers:
+        - url: /static
+          static_dir: pyramid_project/static
+        - url: /.*
+          script: main.application
 
-      APP_NAME = 'pyramidapp:main'
-      APP_ARGS = ({},)
+    Replace `application` with your App Engine app ID, `version` with the version you want to deploy to, and `pyramid_project`
+    in the `static_dir` definition with the directory name above your static assets. If your static assets are in the root
+    directory, you can just put `static`
 
-#. Edit ``runner.py``
+    For more details about app.yaml, see `app.yaml Reference <https://cloud.google.com/appengine/docs/standard/python/config/appref>`_.
 
-   To prevent errors for ``import site``, add this code stanza before
-   ``import site`` in app/runner.py::
 
-      import sys
-      sys.path = [path for path in sys.path if 'site-packages' not in path]
-      import site
+#. Install dependancies
 
-   You will also need to comment out the line that starts with
-   ``assert sys.path`` in the file::
+    .. code-block:: text
 
-      # comment the sys.path assertion out
-      # assert sys.path[:len(cur_sys_path)] == cur_sys_path, (
-      #   "addsitedir() caused entries to be prepended to sys.path")
+      $ pip install -t lib -r requirements.txt
 
-   For GAE development environment 1.3.0 or better, you will also need
-   the following somewhere near the top of the ``runner.py`` file to
-   fix a compatibility issue with ``appengine-monkey``::
 
-      import os
-      os.mkdir = None
+Running Locally
+---------------
 
-#. Run the application.  ``dev_appserver.py`` is typically installed
-   by the SDK in the global path but you need to be sure to run it
-   with Python 2.5 (or whatever version of Python your GAE SDK
-   expects).
+    At this point you should have everything you need to run your Pyramid application locally using dev_appserver.
+    Assuming you have appengine in your $PATH,
 
-   .. code-block:: text
-      :linenos:
+    .. code-block:: text
 
-      $ cd ../..
-      $ python2.5 /usr/local/bin/dev_appserver.py pyramidapp/app/
+      $ dev_appserver.py app.yaml
 
-   Startup success looks something like this:
+    And voilà! You should have a perfectly-running Pyramid application running under Google App Engine, on your local machine.
 
-   .. code-block:: text
+Deploying
+---------
 
-      [chrism@vitaminf pyramid_gae]$ python2.5 \
-                    /usr/local/bin/dev_appserver.py \
-                    pyramidapp/app/
-      INFO     2009-05-03 22:23:13,887 appengine_rpc.py:157] # ... more... 
-      Running application pyramidapp on port 8080: http://localhost:8080
+    Deploying to App Engine is pretty straight forward. If you've successfully launched your application locally,
+    deploying is just as easy.
 
-   You may need to run "Make Symlinks" from the Google App Engine
-   Launcher GUI application if your system doesn't already have the
-   ``dev_appserver.py`` script sitting around somewhere.
+    .. code-block:: text
 
-#. Hack on your pyramid application, using a normal run, debug, restart
-   process.  For tips on how to use the ``pdb`` module within Google
-   App Engine, `see this blog post
-   <http://jjinux.blogspot.com/2008/05/python-debugging-google-app-engine-apps.html>`_.
-   In particular, you can create a function like so and call it to
-   drop your console into a pdb trace::
+      $ appcfg.py update app.yaml
 
-      def set_trace():
-          import pdb, sys
-          debugger = pdb.Pdb(stdin=sys.__stdin__, 
-              stdout=sys.__stdout__)
-          debugger.set_trace(sys._getframe().f_back)
-
-#. `Sign up for a GAE account <http://code.google.com/appengine/>`_
-   and create an application.  You'll need a mobile phone to accept an
-   SMS in order to receive authorization.
-
-#. Edit the application's ID in ``app.yaml`` to match the application
-   name you created during GAE account setup.
-
-   .. code-block:: yaml
-
-      application: mycoolpyramidapp
-
-#. Upload the application
-
-   .. code-block:: text
-
-      $ python2.5 /usr/local/bin/appcfg.py update pyramidapp/app
-
-   You almost certainly won't hit the 3000-file GAE file number limit
-   when invoking this command.  If you do, however, it will look like
-   so:
-
-   .. code-block:: text
-
-       HTTPError: HTTP Error 400: Bad Request
-       Rolling back the update.
-       Error 400: --- begin server output ---
-       Max number of files and blobs is 3000.
-       --- end server output ---
-
-   If you do experience this error, you will be able to get around
-   this by zipping libraries. You can use ``pip`` to create zipfiles
-   from packages.  See :ref:`pip_zip` for more information about this.
-
-   A successful upload looks like so:
-
-   .. code-block:: text
-
-      [chrism@vitaminf pyramidapp]$ python2.5 /usr/local/bin/appcfg.py \
-                                    update ../pyramidapp/app/
-      Scanning files on local disk.
-      Scanned 500 files.
-      # ... more output ...
-      Will check again in 16 seconds.
-      Checking if new version is ready to serve.
-      Closing update: new version is ready to start serving.
-      Uploading index definitions.
-
-#. Visit ``http://<yourapp>.appspot.com`` in a browser.
-
-.. _pip_zip:
-
-Zipping Files Via Pip
----------------------
-
-If you hit the Google App Engine 3000-file limit, you may need to
-create zipfile archives out of some distributions installed in your
-application's virtualenv.
-
-First, see which packages are available for zipping:
-
-.. code-block:: text
-
-   $ bin/pip zip -l
-
-This shows your zipped packages (by default, none) and your unzipped
-packages. You can zip a package like so:
-
-.. code-block:: text
-
-   $ bin/pip zip pytz-2009g-py2.5.egg
-
-Note that it requires the whole egg file name.  For a :app:`Pyramid` app, the
-following packages are good candidates to be zipped.
-
-- Chameleon
-- zope.i18n
-
-Once the zipping procedure is finished you can try uploading again.
+    Your Pyramid application is now live to the world! You can access it by navigation to your domain name, or by
+    `applicationid.appspot.com`, or if you've specified a version outside of your default, it would
+    be `version-dot-applicationid.appspot.com`

--- a/docs/deployment/gae.rst
+++ b/docs/deployment/gae.rst
@@ -31,9 +31,10 @@ Add the following lines:
 
 #. Edit ``main.py``
 
-Add the following lines::
+Add the following lines
 
 .. code-block:: python
+
     from pyramid.paster import get_app, setup_logging
     ini_path = 'production.ini'
     setup_logging(ini_path)
@@ -41,7 +42,7 @@ Add the following lines::
 
 #. Edit ``appengine_config.py``
 
-Add the following lines::
+Add the following lines
 
 .. code-block:: python
 


### PR DESCRIPTION
No longer need appengine-monkey or buildout. Consider also deleting the appengine buildout deployment doc as well. 