### PR TITLE
Add a note that starting pserve with --daemon is no longer supported

### DIFF
--- a/docs/deployment/nginx.rst
+++ b/docs/deployment/nginx.rst
@@ -220,6 +220,10 @@ Running the pserve processes::
     pserve --daemon --pid-file=pserve_5000.pid production.ini http_port=5000
     pserve --daemon --pid-file=pserve_5001.pid production.ini http_port=5001
 
+.. note::
+
+   Starting the pserve process with ``--daemon`` is no longer supported in Pyramid 1.9 and newer.
+
 Step 3: Serving Static Files with Nginx (Optional)
 ==================================================
 

--- a/docs/deployment/nginx.rst
+++ b/docs/deployment/nginx.rst
@@ -217,12 +217,15 @@ hosting the application under a different URL than ``/``.
 
 Running the pserve processes::
 
-    pserve --daemon --pid-file=pserve_5000.pid production.ini http_port=5000
-    pserve --daemon --pid-file=pserve_5001.pid production.ini http_port=5001
+    pserve production.ini http_port=5000
+    pserve production.ini http_port=5001
 
 .. note::
 
-   Starting the pserve process with ``--daemon`` is no longer supported in Pyramid 1.9 and newer.
+   Daemonization of pserve was `deprecated in
+   Pyramid 1.6 <https://docs.pylonsproject.org/projects/pyramid/en/latest/whatsnew-1.6.html#deprecations>`_,
+   then `removed in Pyramid 1.8
+   <https://docs.pylonsproject.org/projects/pyramid/en/latest/whatsnew-1.8.html#backwards-incompatibilities>`_.
 
 Step 3: Serving Static Files with Nginx (Optional)
 ==================================================


### PR DESCRIPTION
For Pyramid 1.9 and newer, you cannot start Pyramid with pserve
--daemon.  This adds a note to the nginx deployment page to call
this out.

When I deployed my first Pyramid app this past August, the developers in IRC were kind enough to let me know that you can no longer start serve with --daemon.  This adds a note to the documentation to call this out.

I don't know if it should be expanded (for Linux users) to use a systemd service instead, but that could be added / expanded to the docs.

I did successfully build this in Sphinx and it looks correct - this is my first PR to a Pylons project, please share any feedback if there is something I can do different / better.

Thanks!