### PR TITLE
Update sqlalchemy_logger.rst

### DIFF
--- a/docs/logging/sqlalchemy_logger.rst
+++ b/docs/logging/sqlalchemy_logger.rst
@@ -89,7 +89,7 @@ Let's subclass Handler now (put this in ``myapp.handlers``)::
            trace = None
            exc = record.__dict__['exc_info']
            if exc:
-               trace = traceback.format_exc(exc)
+               trace = traceback.format_exc()
            log = Log(
                logger=record.__dict__['name'],
                level=record.__dict__['levelname'],


### PR DESCRIPTION
Changed traceback.format_exc() call (removed the exc parameter) as the first argument of format_exc is not the exception to print, it's a limit on how many lines of trace back to print.
Current code fails in my setup (python 3.6.6)

https://docs.python.org/3.6/library/traceback.html

> 
> traceback.format_exc(limit=None, chain=True)
> 
>     This is like print_exc(limit) but returns a string instead of printing to a file.
