### PR TITLE
IndentationError in ./docs/pylons/code/pyramid_handlers.py

### DIFF
--- a/docs/pylons/code/pyramid_handlers.py
+++ b/docs/pylons/code/pyramid_handlers.py
@@ -1,22 +1,22 @@
-    # In the top-level __init__.py
-    from .handlers import Hello
-    def main(global_config, **settings):
-        ...
-        config.include("pyramid_handlers")
-        config.add_handler("hello", "/hello/{action}", handler=Hello) 
+# In the top-level __init__.py
+from .handlers import Hello
+def main(global_config, **settings):
+    ...
+    config.include("pyramid_handlers")
+    config.add_handler("hello", "/hello/{action}", handler=Hello) 
 
-    # In zzz/handlers.py
-    from pyramid_handlers import action
-    class Hello(object):
-        __autoexpose__ = None
+# In zzz/handlers.py
+from pyramid_handlers import action
+class Hello(object):
+    __autoexpose__ = None
 
-        def __init__(self, request):
-            self.request = request
+    def __init__(self, request):
+        self.request = request
 
-        @action
-        def index(self):
-            return Response('Hello world!')
+    @action
+    def index(self):
+        return Response('Hello world!')
 
-        @action(renderer="mytemplate.mak")
-        def bye(self):
-            return {}
+    @action(renderer="mytemplate.mak")
+    def bye(self):
+        return {}


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/Pylons/pyramid_cookbook on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./docs/pylons/code/pyramid_handlers.py:2:4: E999 IndentationError: unexpected indent
    from .handlers import Hello
   ^
1
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree