### PR TITLE
Fix a typo in the "URL generation" section

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -125,3 +125,4 @@ Kacper Krupa, 07/10/2018
 Jonathan Vanasco, 07/11/2018
 Jack Desert, 07/11/2018
 Marcin Lulek, 08/26/2018
+Benjamin Gmurczyk, 10/23/2019

--- a/docs/pylons/other.rst
+++ b/docs/pylons/other.rst
@@ -107,7 +107,7 @@ fragment. Other special keyword arguments are ``_scheme``, ``_host``,
 ``_port``, and ``_app_url``.
 
 The advantage of using these methods rather than hardcoding the URL, is that it
-automatically addds the application prefix (which may be something more than
+automatically adds the application prefix (which may be something more than
 "/" if the application is mounted on a sub-URL).
 
 You can also pass additional positional arguments, and they will be appended


### PR DESCRIPTION
Fixes a small typo in the "URL generation" section on the "Other Pyramid Features" doc.