### PR TITLE
Changed supervisor config file

### DIFF
--- a/docs/deployment/asgi.rst
+++ b/docs/deployment/asgi.rst
@@ -202,8 +202,9 @@ Example Supervisor configuration
 
     [program:asgiapp]
     directory=/path/to/app/
-    command=</path-to-virtualenv>bin/uvicorn app:app --bind unix:/tmp/uvicorn.sock --workers 2 --access-logfile /tmp/uvicorn-access.log --error-logfile /tmp/uvicorn-error.log
+    command=</path-to-virtualenv>/bin/uvicorn app:app --uds /tmp/uvicorn.sock --workers 2 --access-log --log-level error
     user=<app-user>
     autostart=true
     autorestart=true
     redirect_stderr=True
+    [supervisord]


### PR DESCRIPTION
The old supervisor file was not working with uvicorn, changed command line arguments syntax in order to make it work, also added `[supervisord]` as empty to avoid supervisor startup error.